### PR TITLE
Fix broken parallel_coords example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## parallelCoordinates ⇒ <code>parallelCoordinatesChart</code>
 A reusable d3 parallel coordinates generator with statistical coloring
 
-**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/para_coords_example.html)  
+**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/para_coords_example.html)  
 **Author:** Taylor Denouden  
 
 | Param | Type | Description |
@@ -133,7 +133,7 @@ A reusable d3 parallel coordinates generator with statistical coloring
 A reusable d3 scatterplot generator
 
 **Returns**: <code>object</code> - scatterplot chart  
-**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/scatterplot_example.html)  
+**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/scatterplot_example.html)  
 **Author:** Taylor Denouden  
 
 | Param | Type | Description |
@@ -453,7 +453,7 @@ Redraw and transform the chart after parameter changes.
 A reusable d3 vertical line plot generator
 
 **Returns**: <code>object</code> - verticalLine chart  
-**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/vertical_line_example.html)  
+**See**: [example](https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/vertical_line_example.html)  
 **Author:** Taylor Denouden  
 
 | Param | Type | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hakai-charts",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Reusable charts that display arbitrary data",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hakai-charts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Reusable charts that display arbitrary data",
   "main": "index.js",
   "scripts": {

--- a/src/js/para_coords.js
+++ b/src/js/para_coords.js
@@ -9,7 +9,7 @@ require('../styles/para_coords.scss');
  * @module parallelCoordinates
  * @memberof hakaiCharts
  * @author Taylor Denouden
- * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/para_coords_example.html|example}
+ * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/para_coords_example.html|example}
  * @param {String|DOM_node} parent - A dom element to append the chart to
  * @return {parallelCoordinatesChart}
  */

--- a/src/js/scatterplot.js
+++ b/src/js/scatterplot.js
@@ -13,7 +13,7 @@ require('../styles/scatterplot.scss');
  * @module scatterplot
  * @memberof hakaiCharts
  * @author Taylor Denouden
- * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/scatterplot_example.html|example}
+ * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/scatterplot_example.html|example}
  * @param {String|DOM_node} parent A DOM element to append the chart to
  * @return {object} scatterplot chart
  */

--- a/src/js/vertical_line.js
+++ b/src/js/vertical_line.js
@@ -14,7 +14,7 @@ require('../styles/vertical_line.scss');
  * @module verticalLine
  * @memberof hakaiCharts
  * @author Taylor Denouden
- * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.0/examples/vertical_line_example.html|example}
+ * @see {@link https://cdn.rawgit.com/tayden/hakai-charts/v1.1.1/examples/vertical_line_example.html|example}
  * @param {String|DOM_node} parent A DOM element to append the chart to
  * @return {object} verticalLine chart
  */


### PR DESCRIPTION
The rawgit cdn is caching a 404 page because the example was generated before the new tagged version was pushed
